### PR TITLE
Feature/requiretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ default_requiretty: false
   vars:
     default_requiretty: no
     sudo_users:
-      - { name: 'foo', nopasswd: no, norequiretty: yes }
+      - { name: 'foo', nopasswd: no, requiretty: yes }
       - { name: '%sudo', nopasswd: yes }
       - name: '%foo'
         nopasswd: yes
@@ -96,7 +96,7 @@ default_requiretty: false
         commands: '/bin/nano /etc/hosts'
       - name: 'baz'
         nopasswd: yes
-        norequiretty: yes
+        requiretty: yes
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is a list of all the default variables for this role, which are also availa
 
 ```
 # sudo_users:
-#  - { name: '%foo', nopasswd: yes, norequiretty: yes }
+#  - { name: '%foo', nopasswd: yes, requiretty: no }
 #  - { name: 'bar', nopasswd: no }
 #  - name: '%foo'
 #    nopasswd: yes
@@ -47,7 +47,7 @@ Here is a list of all the default variables for this role, which are also availa
 #    commands: '/bin/nano /etc/hosts'
 #  - name: 'baz'
 #    nopasswd: yes
-#    norequiretty: yes
+#    requiretty: no
 
 
 # list of username or %groupname

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is a list of all the default variables for this role, which are also availa
 
 ```
 # sudo_users:
-#  - { name: '%foo', nopasswd: yes }
+#  - { name: '%foo', nopasswd: yes, norequiretty: yes }
 #  - { name: 'bar', nopasswd: no }
 #  - name: '%foo'
 #    nopasswd: yes
@@ -45,10 +45,34 @@ Here is a list of all the default variables for this role, which are also availa
 #  - name: '%foo'
 #    nopasswd: yes
 #    commands: '/bin/nano /etc/hosts'
+#  - name: 'baz'
+#    nopasswd: yes
+#    norequiretty: yes
+
 
 # list of username or %groupname
 sudo_users: []
+
+# Default require tty option 
+# It should be overriden with vars in your playbook based on the actual distribution
+#
+# - hosts: all
+#    tasks:
+#    - include_vars: "os_{{ ansible_distribution }}.yml"
+#
+# It can also be passed explicitely to the role
+#
+# roles:
+#  - role: franklinkim.sudo
+#    default_requiretty: true
+#    sudo_users:
+#      - name: '%sudo'
+#        nopasswd: yes
+#        requiretty: no
+#
+default_requiretty: false
 ```
+
 
 ## Example playbook
 
@@ -57,8 +81,9 @@ sudo_users: []
   roles:
     - franklinkim.sudo
   vars:
+    default_requiretty: no
     sudo_users:
-      - { name: 'foo', nopasswd: no }
+      - { name: 'foo', nopasswd: no, norequiretty: yes }
       - { name: '%sudo', nopasswd: yes }
       - name: '%foo'
         nopasswd: yes
@@ -69,6 +94,9 @@ sudo_users: []
       - name: '%foo'
         nopasswd: yes
         commands: '/bin/nano /etc/hosts'
+      - name: 'baz'
+        nopasswd: yes
+        norequiretty: yes
 ```
 
 ## Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # http://www.ansibleworks.com/docs/playbooks_variables.html#id26
 #
 # sudo_users:
-#  - { name: '%foo', nopasswd: yes }
+#  - { name: '%foo', nopasswd: yes, norequiretty: yes }
 #  - { name: 'bar', nopasswd: no }
 #  - name: '%foo'
 #    nopasswd: yes
@@ -14,6 +14,29 @@
 #  - name: '%foo'
 #    nopasswd: yes
 #    commands: '/bin/nano /etc/hosts'
+#  - name: 'baz'
+#    nopasswd: yes
+#    norequiretty: yes
 
 # list of username or %groupname
 sudo_users: []
+
+# Default require tty option 
+# It should be overriden with vars in your playbook based on the actual distribution
+#
+# - hosts: all
+#    tasks:
+#    - include_vars: "os_{{ ansible_distribution }}.yml"
+#
+# It can also be passed explicitely to the role
+#
+# roles:
+#  - role: franklinkim.sudo
+#    default_requiretty: true
+#    sudo_users:
+#      - name: '%sudo'
+#        nopasswd: yes
+#        requiretty: no
+#
+default_requiretty: false
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # http://www.ansibleworks.com/docs/playbooks_variables.html#id26
 #
 # sudo_users:
-#  - { name: '%foo', nopasswd: yes, norequiretty: yes }
+#  - { name: '%foo', nopasswd: yes, requiretty: no }
 #  - { name: 'bar', nopasswd: no }
 #  - name: '%foo'
 #    nopasswd: yes
@@ -16,7 +16,7 @@
 #    commands: '/bin/nano /etc/hosts'
 #  - name: 'baz'
 #    nopasswd: yes
-#    norequiretty: yes
+#    requiretty: yes
 
 # list of username or %groupname
 sudo_users: []

--- a/templates/etc-sudoers-d-ansible.j2
+++ b/templates/etc-sudoers-d-ansible.j2
@@ -1,5 +1,12 @@
-# {{ansible_managed}}
+# {{ ansible_managed }}
 
 {% for item in sudo_users %}
 {{ item.name }} ALL={{"NOPASSWD: " if item.nopasswd else ""}} {{ item.commands if item.commands is defined else "ALL"}}
+{% if default_requiretty -%} 
+{{ "Defaults:" ~ item.name ~ " !requiretty" if item.requiretty is defined and not item.requiretty else "" }}
+{% else -%}
+{{ "Defaults:" ~ item.name ~  " requiretty"  if item.requiretty is defined and     item.requiretty else "" }}
+{% endif -%}
 {% endfor %}
+
+

--- a/test.yml
+++ b/test.yml
@@ -4,6 +4,6 @@
   roles:
     - franklinkim.sudo
   vars:
-    default_requiretty: false
+    default_requiretty: yes
     sudo_users:
-      - { name: '%sudo', nopasswd: yes, norequiretty: yes }
+      - { name: '%sudo', nopasswd: yes, requiretty: no }

--- a/test.yml
+++ b/test.yml
@@ -4,5 +4,6 @@
   roles:
     - franklinkim.sudo
   vars:
+    default_requiretty: false
     sudo_users:
-      - { name: '%sudo', nopasswd: yes }
+      - { name: '%sudo', nopasswd: yes, norequiretty: yes }


### PR DESCRIPTION
Added new 'requiretty' option to sudo_users. This is an optional boolean field.
Varialble 'default_requiretty' controls whether to actually insert 
Defaults:<user> requiretty or Defaults:<user> requiretty !requiretty directives in sudoers file, avoiding redundat declarations with the default policy.
