### PR TITLE
ability to write multiple sudoers files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,5 @@ sudo_package: sudo
 sudo_users: []
 # list of username or %groupname and their defaults
 sudo_defaults: []
+# default sudoers file
+sudo_default_file: ansible

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,4 +18,4 @@ sudo_users: []
 # list of username or %groupname and their defaults
 sudo_defaults: []
 # default sudoers file
-sudo_default_file: ansible
+sudo_sudoers_file: ansible

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,11 +2,9 @@
 
 - name: Creating sudoers configuration under /etc/sudoers.d
   template:
-    src: "{{ item }}.j2"
-    dest: "/{{ item }}"
+    src: "etc/sudoers.d/ansible.j2"
+    dest: "/etc/sudoers.d/{{ sudo_default_file }}"
     validate: "visudo -cf %s"
     owner: root
     group: root
     mode: "0440"
-  with_items:
-    - "etc/sudoers.d/ansible"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -3,7 +3,7 @@
 - name: Creating sudoers configuration under /etc/sudoers.d
   template:
     src: "etc/sudoers.d/ansible.j2"
-    dest: "/etc/sudoers.d/{{ sudo_default_file }}"
+    dest: "/etc/sudoers.d/{{ sudo_sudoers_file }}"
     validate: "visudo -cf %s"
     owner: root
     group: root


### PR DESCRIPTION
Use case: We deploy application specific users and system users in a separate task, and they overwrite the same /etc/sudoers.d/ansible file

this allows us to have a specific file for apps and one for system users