### PR TITLE
update package repository cache prior installing

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: Installing package
-  action: "{{ ansible_pkg_mgr }} pkg={{ sudo_package }} state=present"
+  action: "{{ ansible_pkg_mgr }} pkg={{ sudo_package }} state=present update_cache=yes"


### PR DESCRIPTION
Neccessary, for example, to use it as role for ansible-container