### PR TITLE
Allow setting sudoers directory path and set some FreeBSD vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ sudo_defaults: []
 sudo_sudoers_file: ansible
 # delete other files in /etc/sudoers.d/
 purge_other_sudoers_files: no
+# path of the sudoers.d directory
+sudo_sudoers_d_path: /etc/sudoers.d/
 
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,5 @@ sudo_defaults: []
 sudo_sudoers_file: ansible
 # delete other files in /etc/sudoers.d/
 purge_other_sudoers_files: no
+# path of the sudoers.d directory
+sudo_sudoers_d_path: /etc/sudoers.d

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,25 +1,25 @@
 ---
 
-- name: "Creating sudoers configuration in /etc/sudoers.d/{{ sudo_sudoers_file }}"
+- name: "Creating sudoers configuration in {{ sudo_sudoers_d_path }}/{{ sudo_sudoers_file }}"
   template:
     src: "etc/sudoers.d/ansible.j2"
-    dest: "/etc/sudoers.d/{{ sudo_sudoers_file }}"
+    dest: "{{ sudo_sudoers_d_path }}/{{ sudo_sudoers_file }}"
     validate: "visudo -cf %s"
     owner: root
     group: "{{ sudo_sudoers_group }}"
     mode: "0440"
 
-- name: List files in /etc/sudoers.d
+- name: "List files in {{ sudo_sudoers_d_path }}"
   find:
-    paths: /etc/sudoers.d
+    paths: "{{ sudo_sudoers_d_path }}"
     patterns: "*"
   register: sudoers_contents
   changed_when: false
   when: purge_other_sudoers_files
 
-- name: Remove unmanaged /etc/sudoers.d/ files
+- name: "Remove unmanaged {{ sudo_sudoers_d_path }} files"
   file:
-    path: "/etc/sudoers.d/{{ item.path|basename }}"
+    path: "{{ sudo_sudoers_d_path }}/{{ item.path|basename }}"
     state: absent
   loop: "{{ sudoers_contents.files }}"
   loop_control:

--- a/vars/freebsd.yml
+++ b/vars/freebsd.yml
@@ -1,0 +1,3 @@
+---
+sudo_pkg_mgr_opts: ''
+sudo_sudoers_group: wheel


### PR DESCRIPTION
Some package managers keep all files related to the package in /usr/local. In particular, on FreeBSD this means that the sudoers directory path is actually /usr/local/etc/sudoers.d rather than /etc/sudoers.d.

This PR adds a variable to set the path to the sudoers.d directory.

Additionally, this PR sets the sudo_pkg_mgr_opts and sudo_sudoers_group variables correctly for FreeBSD.