### PR TITLE
Added full path for visudo due to issue on RHEL

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -4,7 +4,7 @@
   template:
     src: "etc/sudoers.d/ansible.j2"
     dest: "{{ sudo_sudoers_d_path }}/{{ sudo_sudoers_file }}"
-    validate: "visudo -cf %s"
+    validate: "/usr/sbin/visudo -cf %s"
     owner: root
     group: "{{ sudo_sudoers_group }}"
     mode: "0440"


### PR DESCRIPTION
This is similar to issue #25.

When running the role with "become:true", some of our RHEL hosts are failing due to not having the path to visudo.  This can be resolved by using the full path as in this PR.

If the location of visudo differs between OSs, the path could be added as a variable depending on ansible_os_family, etc.

Error:
TASK [weareinteractive.sudo : Creating sudoers configuration in /etc/sudoers.d/ansible] ****************************************fatal: [host]: FAILED! => {"changed": false, "checksum": "fd6f3a01a69b3a602c71431d588574a2d99bbed0", "cmd": "visudo -cf /tmp/ansible-tmp-1569597464.829656-26667650723891/source", "msg": "[Errno 2] No such file or directory", "rc": 2}