### PR TITLE
case-sensitive filename, make path of visudo configurable

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -4,7 +4,7 @@
   template:
     src: "etc/sudoers.d/ansible.j2"
     dest: "{{ sudo_sudoers_d_path }}/{{ sudo_sudoers_file }}"
-    validate: "/usr/sbin/visudo -cf %s"
+    validate: "{{ sudo_visudo }} -cf %s"
     owner: root
     group: "{{ sudo_sudoers_group }}"
     mode: "0440"

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,3 +1,4 @@
 ---
 sudo_pkg_mgr_opts: ''
 sudo_sudoers_group: wheel
+sudo_visudo: '/usr/local/sbin/visudo'

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,3 +1,4 @@
 ---
 sudo_pkg_mgr_opts: update_cache=yes
 sudo_sudoers_group: root
+sudo_visudo: '/usr/sbin/visudo'


### PR DESCRIPTION
On OpenBSD visudo has a different location - therefore the path of visudo should be configurable.
thanks!