### PR TITLE
Case-sensitive FreeBSD and visudo path

### DIFF
--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,3 +1,4 @@
 ---
 sudo_pkg_mgr_opts: ''
 sudo_sudoers_group: wheel
+sudo_visudo: '/usr/local/sbin/visudo'


### PR DESCRIPTION
Problem
-------------

- FreeBSD is capitalized when doing the string comparisons [here](https://github.com/weareinteractive/ansible-sudo/blob/master/tasks/vars.yml#L5) but the var file's name is lowercased
- FreeBSD's `visudo(8)` (like that on OpenBSD) is located under `/usr/local/sbin`, not `/usr/sbin` as on most GNU/Linux distros

Solution
-------------

- Rename [freebsd.yml](https://github.com/weareinteractive/ansible-sudo/blob/master/vars/freebsd.yml) to FreeBSD.yml
- Include the path to the FreeBSD `visudo(8)` binary, like in the OpenBSD.yml var file

Testing
-------------

- Worked to install and configure `sudo(8)` on FreeBSD 12.1.