### PR TITLE
Handle multiple os_family vars in single file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,5 @@
 ---
 
-- import_tasks: vars.yml
-  tags:
-    - system
-    - sudo
-    - vars
-    - sudo-vars
-
 - import_tasks: install.yml
   tags:
     - system

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -1,8 +1,0 @@
----
-
-- name: Including variables for distribution
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - default.yml

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,4 +1,0 @@
----
-sudo_pkg_mgr_opts: ''
-sudo_sudoers_group: wheel
-sudo_visudo: '/usr/local/sbin/visudo'

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,4 +1,0 @@
----
-sudo_pkg_mgr_opts: ''
-sudo_sudoers_group: wheel
-sudo_visudo: '/usr/local/sbin/visudo'

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,4 +1,0 @@
----
-sudo_pkg_mgr_opts: update_cache=yes
-sudo_sudoers_group: root
-sudo_visudo: '/usr/sbin/visudo'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,21 @@
+---
+_sudo_pkg_mgr_opts:
+  default: update_cache=yes
+  FreeBSD: ''
+  OpenBSD: ''
+
+sudo_pkg_mgr_opts: "{{ _sudo_pkg_mgr_opts[ansible_os_family] | default(_sudo_pkg_mgr_opts['default']) }}"
+
+_sudo_sudoers_group:
+  default: root
+  FreeBSD: wheel
+  OpenBSD: wheel
+
+sudo_sudoers_group: "{{ _sudo_sudoers_group[ansible_os_family] | default(_sudo_sudoers_group['default']) }}"
+
+_sudo_visudo:
+  default: '/usr/sbin/visudo'
+  FreeBSD: '/usr/local/sbin/visudo'
+  OpenBSD: '/usr/local/sbin/visudo'
+
+sudo_visudo: "{{ _sudo_visudo[ansible_os_family] | default(_sudo_visudo['default']) }}"


### PR DESCRIPTION
##  Problem

When using this role inside other roles on distributions like Ubuntu it seems redundant to have to specify the default vars again since vars use `"{{ ansible_distribution }}.yml"` or `"{{ ansible_os_family }}.yml"` before `default.yml`. 

## Solution

Handle vars inside `vars/main.yml` instead of a separate task looping in var files.  

## Testing

Worked to install and configure sudo(8) on FreeBSD 12.1 and Ubuntu 18.04
