### PR TITLE
Use comment filter to support multiline comments

### DIFF
--- a/templates/etc/sudoers.d/ansible.j2
+++ b/templates/etc/sudoers.d/ansible.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for item in sudo_defaults %}
 Defaults{{ ":" ~ item.name if item.name is defined else "" }} {{ item.defaults }}


### PR DESCRIPTION
The current `ansible_managed` text in the template is not multiline save.
This PR use the ansible comment filter to change this.