### PR TITLE
Added Alias configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Here is a list of all the default variables for this role, which are also availa
 
 ```yaml
 ---
+# sudo_sudoers_user_aliases:
+#  WEBADMINS:
+#    - webadmin1
+#    - webadmin2
+# sudo_sudoers_cmnd_aliases:
+#  WEBCOMMANDS:
+#    - /bin/systemctl status nginx
+#    - /bin/systemctl start nginx
+#    - /bin/systemctl stop nginx
+#    - /bin/systemctl restart nginx
+#  PACKAGECOMMANDS: '/bin/apt, /bin/yum'
 # sudo_defaults:
 #  - defaults: env_reset
 #  - name: user1
@@ -89,6 +100,19 @@ This is an example playbook:
   roles:
     - weareinteractive.sudo
   vars:
+    sudo_sudoers_user_aliases:
+      WEBADMINS:
+        - webadmin1
+        - webadmin2
+    sudo_sudoers_runas_aliases:
+      WEBUSERS: 'www-data, www'
+    sudo_sudoers_cmnd_aliases:
+      WEBCOMMANDS:
+        - /bin/systemctl status nginx
+        - /bin/systemctl start nginx
+        - /bin/systemctl stop nginx
+        - /bin/systemctl restart nginx
+      PACKAGECOMMANDS: '/bin/apt, /bin/yum'
     sudo_defaults:
       - defaults: env_reset
       - defaults: secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -112,6 +136,10 @@ This is an example playbook:
       - name: '%group4'
         users: 'user1,user2'
         groups: 'group1,group2'
+      - name: WEBADMINS
+        commands: WEBCOMMANDS
+        users: WEBUSERS
+        groups: WEBUSERS
     purge_other_sudoers_files: yes
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,17 @@
 ---
+# sudo_sudoers_user_aliases:
+#  WEBADMINS:
+#    - webadmin1
+#    - webadmin2
+# sudo_sudoers_cmnd_aliases:
+#  WEBCOMMANDS:
+#    - /bin/systemctl status nginx
+#    - /bin/systemctl start nginx
+#    - /bin/systemctl stop nginx
+#    - /bin/systemctl restart nginx
+#  PACKAGECOMMANDS: '/bin/apt, /bin/yum'
+# sudo_sudoers_runas_aliases:
+#  WEBUSERS: 'www-data, www'
 # sudo_defaults:
 #  - defaults: env_reset
 #  - name: user1
@@ -15,6 +28,10 @@
 #      - /bin/df
 #  - name: '%group4'
 #    hosts: 127.0.0.1
+#  - name: WEBADMINS
+#    commands: WEBCOMMANDS
+#    users: WEBUSERS
+#    groups: WEBUSERS
 
 # package name (version)
 sudo_package: sudo
@@ -22,6 +39,12 @@ sudo_package: sudo
 sudo_users: []
 # list of username or %groupname and their defaults
 sudo_defaults: []
+# dictionary of user alias definition
+sudo_sudoers_user_aliases: []
+# dictionary of cmnd alias definition
+sudo_sudoers_cmnd_aliases: []
+# dictionary of runas alias definition
+sudo_sudoers_runas_aliases: []
 # default sudoers file
 sudo_sudoers_file: ansible
 # path of the sudoers.d directory

--- a/templates/etc/sudoers.d/ansible.j2
+++ b/templates/etc/sudoers.d/ansible.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 
 {{ sudo_aliases_comment | comment }}
-{% if sudo_sudoers_users_aliases is mapping %}
+{% if sudo_sudoers_user_aliases is mapping %}
 {% for key, value in sudo_sudoers_user_aliases.items() %}
 User_Alias {{ key }} = {{ value if value is string else value | join(', ') }}
 {% endfor %}

--- a/templates/etc/sudoers.d/ansible.j2
+++ b/templates/etc/sudoers.d/ansible.j2
@@ -1,5 +1,22 @@
 {{ ansible_managed | comment }}
 
+{{ sudo_aliases_comment | comment }}
+{% if sudo_users_aliases is mapping %}
+{% for key, value in sudo_sudoers_user_aliases.items() %}
+User_Alias {{ key }} = {{ value if value is string else value | join(', ') }}
+{% endfor %}
+{% endif %}
+{% if sudo_runas_aliases is mapping %}
+{% for key, value in sudo_sudoers_runas_aliases.items() %}
+Runas_Alias {{ key }} = {{ value if value is string else value | join(', ') }}
+{% endfor %}
+{% endif %}
+{% if sudo_cmnd_aliases is mapping %}
+{% for key, value in sudo_sudoers_cmnd_aliases.items() %}
+Cmnd_Alias {{ key }} = {{ value if value is string else value | join(', ') }}
+{% endfor %}
+{% endif %}
+
 {% for item in sudo_defaults %}
 Defaults{{ ":" ~ item.name if item.name is defined else "" }} {{ item.defaults }}
 {% endfor %}

--- a/templates/etc/sudoers.d/ansible.j2
+++ b/templates/etc/sudoers.d/ansible.j2
@@ -1,17 +1,17 @@
 {{ ansible_managed | comment }}
 
 {{ sudo_aliases_comment | comment }}
-{% if sudo_users_aliases is mapping %}
+{% if sudo_sudoers_users_aliases is mapping %}
 {% for key, value in sudo_sudoers_user_aliases.items() %}
 User_Alias {{ key }} = {{ value if value is string else value | join(', ') }}
 {% endfor %}
 {% endif %}
-{% if sudo_runas_aliases is mapping %}
+{% if sudo_sudoers_runas_aliases is mapping %}
 {% for key, value in sudo_sudoers_runas_aliases.items() %}
 Runas_Alias {{ key }} = {{ value if value is string else value | join(', ') }}
 {% endfor %}
 {% endif %}
-{% if sudo_cmnd_aliases is mapping %}
+{% if sudo_sudoers_cmnd_aliases is mapping %}
 {% for key, value in sudo_sudoers_cmnd_aliases.items() %}
 Cmnd_Alias {{ key }} = {{ value if value is string else value | join(', ') }}
 {% endfor %}

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -5,6 +5,17 @@
   roles:
     - weareinteractive.sudo
   vars:
+    sudo_sudoers_user_aliases:
+      WEBADMINS:
+        - webadmin1
+        - webadmin2
+    sudo_sudoers_cmnd_aliases:
+      WEBCOMMANDS:
+        - /bin/systemctl status nginx
+        - /bin/systemctl start nginx
+        - /bin/systemctl stop nginx
+        - /bin/systemctl restart nginx
+      PACKAGECOMMANDS: '/bin/apt, /bin/yum'
     sudo_defaults:
       - defaults: env_reset
       - defaults: secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -28,4 +39,8 @@
       - name: '%group4'
         users: 'user1,user2'
         groups: 'group1,group2'
+      - name: WEBADMINS
+        commands: WEBCOMMANDS
+        users: WEBUSERS
+        groups: WEBUSERS
     purge_other_sudoers_files: yes

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -2,3 +2,4 @@
 sudo_pkg_mgr_opts: update_cache=yes
 sudo_sudoers_group: root
 sudo_visudo: '/usr/sbin/visudo'
+sudo_aliases_comment: 'Aliases definitions'


### PR DESCRIPTION
I add  User_Alias, Runas_Alias and Cmnd_Alias configuration like you suggested in  [pull31](https://github.com/weareinteractive/ansible-sudo/pull/31)
Host_Alias is not included as it is no problem to have a host specific sudoer configuration via ansible and I think it is not a good way to handle it.
