### PR TITLE
Added the possibility to define additional sudoers files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ sudo_users: []
 sudo_defaults: []
 # default sudoers file
 sudo_sudoers_file: ansible
+# list for additional sudoers files
+sudo_sudoers_additional_files: []
 # path of the sudoers.d directory
 sudo_sudoers_d_path: /etc/sudoers.d
 # delete other files in `sudo_sudoers_d_path`
@@ -114,8 +116,14 @@ This is an example playbook:
         groups: 'group1,group2'
     purge_other_sudoers_files: yes
 
-```
+    sudo_sudoers_additional_files:
+      - web
+    sudo_users_web:
+      - name: 'webuser1'
 
+```
+If you are going to make use of sudo_sudoers_additional_files then all the other variables are available like before, but you have to suffix them with the filename.
+This is like in the upper example the name `web`.
 
 ## Testing
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,8 @@ sudo_users: []
 sudo_defaults: []
 # default sudoers file
 sudo_sudoers_file: ansible
+# list for additional sudoers files
+sudo_sudoers_additional_files: []
 # path of the sudoers.d directory
 sudo_sudoers_d_path: /etc/sudoers.d
 # delete other files in `sudo_sudoers_d_path`

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,7 +9,7 @@
     group: "{{ sudo_sudoers_group }}"
     mode: "0440"
 
-- name: "Creating sudoers configuration in {{ sudo_sudoers_d_path }}/{{ item }}"
+- name: "Creating additional sudoers configurations"
   vars:
     sudo_sudoers_user_aliases: "{{ lookup('vars', 'sudo_sudoers_user_aliases_' + item, default='') }}"
     sudo_sudoers_runas_aliases: "{{ lookup('vars', 'sudo_sudoers_runas_aliases_' + item, default='') }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,6 +9,24 @@
     group: "{{ sudo_sudoers_group }}"
     mode: "0440"
 
+- name: "Creating sudoers configuration in {{ sudo_sudoers_d_path }}/{{ item }}"
+  vars:
+    sudo_sudoers_user_aliases: "{{ lookup('vars', 'sudo_sudoers_user_aliases_' + item, default='') }}"
+    sudo_sudoers_runas_aliases: "{{ lookup('vars', 'sudo_sudoers_runas_aliases_' + item, default='') }}"
+    sudo_sudoers_cmnd_aliases: "{{ lookup('vars', 'sudo_sudoers_cmnd_aliases_' + item, default='') }}"
+    sudo_defaults: "{{ lookup('vars', 'sudo_defaults_' + item, default='') }}"
+    sudo_users: "{{ lookup('vars', 'sudo_users_' + item, default='') }}"
+  template:
+    src: "etc/sudoers.d/ansible.j2"
+    dest: "{{ sudo_sudoers_d_path }}/{{ item }}"
+    validate: "{{ sudo_visudo }} -cf %s"
+    owner: root
+    group: "{{ sudo_sudoers_group }}"
+    mode: "0440"
+  loop: "{{ sudo_sudoers_additional_files | list }}"
+  when:
+    - (sudo_sudoers_additional_files | length > 0)
+
 - name: "List files in {{ sudo_sudoers_d_path }}"
   find:
     paths: "{{ sudo_sudoers_d_path }}"
@@ -27,3 +45,4 @@
   when:
     - purge_other_sudoers_files | bool
     - (item.path|basename) != sudo_sudoers_file
+    - (item.path|basename) not in sudo_sudoers_additional_files

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -29,3 +29,8 @@
         users: 'user1,user2'
         groups: 'group1,group2'
     purge_other_sudoers_files: yes
+
+    sudo_sudoers_additional_files:
+      - web
+    sudo_users_web:
+      - name: 'webuser1'


### PR DESCRIPTION
This is helpful as the option purge_other_sudoers_files would also delete our added configuration if we would run the role multiple times.

It works by adding a suffix to the existing variables, for example if you add 
```sudo_sudoers_additional_files:
     - web
```
Then one variable to configure this file would look like this:
```sudo_users_web:
     - name: www-html
```

The changes will work with the current master branch, but also together with https://github.com/weareinteractive/ansible-sudo/pull/36 or https://github.com/weareinteractive/ansible-sudo/pull/37