### PR TITLE
Fix Ansible deprecation warning

### DIFF
--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -3,6 +3,6 @@
 - name: Including variables for distribution
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - "{{ ansible_facts['os_family'] }}.yml"
     - default.yml


### PR DESCRIPTION
This pull request resolves the Ansible deprecation warning observed in newer Ansible versions which advises to use ansible_facts instead of ansible_ variables.

```
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: roles/weareinteractive.sudo/tasks/vars.yml:6:7
4   include_vars: "{{ item }}"
5   with_first_found:
6     - "{{ ansible_distribution }}.yml"
        ^ column 7
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```

Thanks for all your work to create this excellent Ansible role!